### PR TITLE
Post multiple selected artboards to Slack in the order they appear in the Sketch document

### DIFF
--- a/api.js
+++ b/api.js
@@ -107,7 +107,7 @@ function getGroupIDs() {
 
 
 function exportArtboardsAndSendTo(recipient) {
-	var loop = [selection objectEnumerator]
+	var loop = [selection reverseObjectEnumerator]
 	while (item = [loop nextObject]) {
 		if (item.className() == "MSArtboardGroup") {
 			var path = NSTemporaryDirectory() + item.name() + ".png"

--- a/api.js
+++ b/api.js
@@ -122,5 +122,6 @@ function postFile(path, recipient) {
 	task.setLaunchPath("/usr/bin/curl");
 	var args = NSArray.arrayWithObjects("-F", "token=" + getActiveToken(), "-F", "file=@" + path, "-F", "channels=" + recipient, "https://slack.com/api/files.upload", nil);
 	task.setArguments(args);
-    task.launch();
+  task.launch();
+  task.waitUntilExit();
 }


### PR DESCRIPTION
This change ensures that multiple selected artboards are posted to Slack in the order they appear in the Sketch document (top to bottom). This allows artboards organized as flows to retain their order in Slack.

It should be noted that this makes posting multiple artboards a bit slower, as it essentially as the Slack posting task is now synchronous instead of asynchronous. It does not affect the speed of posting single artboards.
